### PR TITLE
Remove rows with empty Benchmark column instead of any empty value

### DIFF
--- a/jobs-monitoring-health-back/src/main/java/org/jboss/qa/monitoring/health/util/CsvLoader.java
+++ b/jobs-monitoring-health-back/src/main/java/org/jboss/qa/monitoring/health/util/CsvLoader.java
@@ -50,7 +50,7 @@ public class CsvLoader {
 
             ObjectMapper mapper = new ObjectMapper();
             // Removes records with empty values, in practise used to skip blank lines in CSV
-            readAll.removeIf(metric -> mapper.convertValue(metric, LinkedHashMap.class).containsValue(""));
+            readAll.removeIf(metric -> mapper.convertValue(metric, LinkedHashMap.class).get("Benchmark").equals(""));
             mapper.writerWithDefaultPrettyPrinter().writeValue(output, readAll);
 
             reader = new FileReader(output);


### PR DESCRIPTION
Lets remove rows with empty "Benchmark" column instead of any empty value. This will remove blank lines and any correct test should have not empty "Benchmark" column.